### PR TITLE
updates uuid dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["os", "api-bindings", "hardware-support"]
 futures01 = { package = "futures", version = "0.1.25" }
 futures = { version = "0.3", features = ["compat",] }
 tokio = "0.1.13"
-uuid = "0.7.1"
+uuid = "0.8.1"
 [target."cfg(any(target_os = \"linux\", target_os = \"android\"))".dependencies]
 dbus = "0.6.3"
 dbus-tokio = "0.3.0"


### PR DESCRIPTION
Updates the library to use `uuid 0.8`. I'm not sure if this breaks compatibility, but for what its worth the tests still work on my devices.

I'm using this library (thanks btw!) in conjunction with a newer version of `uuid`, so I figured why not have this also use the newer version if it doesn't break anything.