### PR TITLE
Upgrade dbus crate using dbus-crossroads as tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,20 @@ repository = "https://github.com/dfrankland/bluster"
 keywords = ["BLE", "Bluetooth", "Bluez", "CoreBluetooth", "USB"]
 categories = ["os", "api-bindings", "hardware-support"]
 [dependencies]
-futures01 = { package = "futures", version = "0.1.25" }
-futures = { version = "0.3", features = ["compat",] }
-tokio = "0.1.13"
+futures = "0.3"
+tokio = "0.2"
 uuid = "0.8.1"
+log = "0.4"
 [target."cfg(any(target_os = \"linux\", target_os = \"android\"))".dependencies]
-dbus = "0.6.3"
-dbus-tokio = "0.3.0"
+dbus = "^0.8.4"
+dbus-tokio = "^0.5.2"
+dbus-crossroads = "^0.2.1"
 [target."cfg(any(target_os = \"macos\", target_os = \"ios\"))".dependencies]
 objc = "0.2.7"
 objc-foundation = "0.1.1"
 objc_id = "0.1.1"
 [target."cfg(any(target_os = \"windows\", target_os = \"freebsd\"))".dependencies]
 libusb = "0.3.0"
+
+[dev-dependencies]
+pretty_env_logger = "0.2"

--- a/src/gatt/event.rs
+++ b/src/gatt/event.rs
@@ -1,4 +1,4 @@
-use futures01::sync::{mpsc, oneshot};
+use futures::channel::{mpsc, oneshot};
 
 pub type EventSender = mpsc::Sender<Event>;
 pub type ResponseSender = oneshot::Sender<Response>;

--- a/src/peripheral/bluez/common.rs
+++ b/src/peripheral/bluez/common.rs
@@ -1,5 +1,4 @@
-use dbus::tree::{MTFn, Tree as DbusTree};
-use dbus_tokio::tree::{ADataType, ATree};
+use dbus_crossroads::Crossroads;
 use std::sync::Arc;
 
 use crate::gatt;
@@ -10,7 +9,6 @@ pub enum GattDataType {
     // Service(Arc<gatt::service::Service>),
     Characteristic(Arc<gatt::characteristic::Characteristic>),
     Descriptor(Arc<gatt::descriptor::Descriptor>),
-    None,
 }
 
 impl GattDataType {
@@ -37,14 +35,4 @@ impl GattDataType {
     }
 }
 
-#[derive(Copy, Clone, Default, Debug)]
-pub struct TData;
-impl ADataType for TData {
-    type ObjectPath = GattDataType;
-    type Property = ();
-    type Interface = ();
-    type Method = ();
-    type Signal = ();
-}
-
-pub type Tree = DbusTree<MTFn<ATree<TData>>, ATree<TData>>;
+pub type Tree = Crossroads;

--- a/src/peripheral/bluez/constants.rs
+++ b/src/peripheral/bluez/constants.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 pub const DBUS_PROPERTIES_IFACE: &str = "org.freedesktop.DBus.Properties";
 pub const DBUS_OBJECTMANAGER_IFACE: &str = "org.freedesktop.DBus.ObjectManager";
 
@@ -21,3 +23,5 @@ pub const BLUEZ_ERROR_FAILED: &str = "org.bluez.Error.Failed";
 pub const BLUEZ_ERROR_NOTSUPPORTED: &str = "org.bluez.Error.NotSupported";
 
 pub const PATH_BASE: &str = "/org/bluez/example";
+
+pub const BLUEZ_DBUS_TIMEOUT: Duration = Duration::from_secs(30);

--- a/src/peripheral/bluez/gatt/characteristic.rs
+++ b/src/peripheral/bluez/gatt/characteristic.rs
@@ -1,34 +1,28 @@
 use dbus::{
-    arg::{Iter, RefArg, Variant},
-    tree::{Access, EmitsChangedSignal, MethodErr, PropInfo},
-    Message, MessageItem, Path,
+    arg::{RefArg, Variant},
+    channel::Sender,
+    nonblock::stdintf::org_freedesktop_dbus::PropertiesPropertiesChanged,
+    tree::MethodErr,
+    Message, Path,
 };
-use dbus_tokio::tree::{AFactory, ATree};
-use futures01::{
-    future,
+use futures::{
+    channel::{mpsc, oneshot},
     prelude::*,
-    sync::{mpsc, oneshot},
 };
-use std::{
-    collections::HashMap,
-    rc::Rc,
-    sync::{Arc, Mutex},
-    thread,
-};
-use tokio::runtime::current_thread::block_on_all;
+use std::{collections::HashMap, sync::Arc};
 
 use super::{
     super::{
         common,
-        constants::{
-            BLUEZ_ERROR_FAILED, BLUEZ_ERROR_NOTSUPPORTED, DBUS_PROPERTIES_IFACE,
-            GATT_CHARACTERISTIC_IFACE,
-        },
+        common::GattDataType,
+        constants::{BLUEZ_ERROR_FAILED, BLUEZ_ERROR_NOTSUPPORTED, GATT_CHARACTERISTIC_IFACE},
         Connection,
     },
     flags::Flags,
 };
 use crate::{gatt, Error};
+
+type OptionsMap = HashMap<String, Variant<Box<dyn RefArg>>>;
 
 #[derive(Debug, Clone)]
 pub struct Characteristic {
@@ -43,121 +37,56 @@ impl Characteristic {
         service: &Path<'static>,
         index: u64,
     ) -> Result<Self, Error> {
-        let factory = AFactory::new_afn::<common::TData>();
-
-        // Setup value property for read / write by other methods
-        let value = Arc::new(Mutex::new(characteristic.value.clone()));
-        let value_property = {
-            let property = factory
-                .property::<&[u8], _>("Value", ())
-                .emits_changed(EmitsChangedSignal::True)
-                .access({
-                    let is_read_only_value =
-                        characteristic.properties.is_read_only() && characteristic.value.is_some();
-                    if is_read_only_value {
-                        Access::Read
-                    } else {
-                        Access::ReadWrite
-                    }
-                })
-                .on_get({
-                    let on_get_value = Arc::clone(&value);
-                    move |i, _| {
-                        let value = on_get_value
-                            .lock()
-                            .unwrap()
-                            .clone()
-                            .unwrap_or_else(Vec::new);
-                        i.append(value);
-                        Ok(())
-                    }
-                })
-                .on_set({
-                    let on_set_value = Arc::clone(&value);
-                    move |i, _| {
-                        let value = i.read()?;
-                        on_set_value.lock().unwrap().replace(value);
-                        Ok(())
-                    }
-                });
-            Arc::new(property)
-        };
-
-        // Setup a channel for notifications
-        let object_path_name = format!("{}/characteristic{:04}", service, index);
+        let object_path: Path = format!("{}/characteristic{:04}", service, index).into();
         let object_path_data = common::GattDataType::Characteristic(Arc::clone(characteristic));
+        // Setup a channel for notifications
         let (message_sender, message_receiver) = mpsc::channel(1);
         {
-            let value_property = Arc::clone(&value_property);
+            let object_path = object_path.clone();
             let connection = Arc::clone(connection);
-            let object_path =
-                factory.object_path(object_path_name.clone(), object_path_data.clone());
-            Arc::clone(&connection).runtime.lock().unwrap().spawn(
+            tokio::spawn(
                 message_receiver
                     .map(move |notification: Vec<u8>| {
-                        let message = Message::new_method_call(
-                            connection.fallback.unique_name(),
-                            object_path.get_name(),
-                            DBUS_PROPERTIES_IFACE,
-                            "Set",
-                        )
-                        .unwrap()
-                        .append1(MessageItem::Variant(Box::new(
-                            MessageItem::new_array(
-                                notification
-                                    .iter()
-                                    .map(|b| MessageItem::Byte(*b))
-                                    .collect::<Vec<MessageItem>>(),
-                            )
-                            .unwrap(),
-                        )));
-
-                        let factory = AFactory::new_afn::<common::TData>();
-                        let prop_info = PropInfo {
-                            msg: &message,
-                            method: &factory.method("Set", (), |_| Ok(vec![])),
-                            prop: &value_property,
-                            iface: &factory.interface(GATT_CHARACTERISTIC_IFACE, ()),
-                            path: &object_path,
-                            tree: &factory.tree(ATree::new()),
+                        // For notifications, BlueZ wants a PropertiesChanged
+                        // signal on the optional `Value` property. It doesn't
+                        // require that the property actually exists.
+                        let mut props = HashMap::new();
+                        props.insert("Value".to_owned(), Variant(Box::new(notification) as _));
+                        let signal = PropertiesPropertiesChanged {
+                            interface_name: GATT_CHARACTERISTIC_IFACE.to_string(),
+                            changed_properties: props,
+                            invalidated_properties: Vec::new(),
                         };
-                        let set_result =
-                            value_property.set_as_variant(&mut Iter::new(&message), &prop_info);
-                        if let Ok(emits_changed) = set_result {
-                            if let Some(emits_changed_message) = emits_changed {
-                                return future::Either::A(
-                                    Rc::clone(&connection.fallback).send(emits_changed_message),
-                                );
-                            }
-                        }
-                        future::Either::B(())
+                        let mut signal_message = Message::signal(
+                            &object_path,
+                            &"org.freedesktop.DBus.Properties".into(),
+                            &"PropertiesChanged".into(),
+                        );
+                        signal_message.append_all(signal);
+                        connection.default.send(signal_message).ok();
                     })
-                    .for_each(|_| Ok(())),
+                    .collect::<()>(),
             );
         }
 
-        let gatt_characteristic = factory
-            .interface(GATT_CHARACTERISTIC_IFACE, ())
-            .add_m(factory.amethod("ReadValue", (), move |method_info| {
-                let offset = method_info
-                    .msg
-                    .get1::<HashMap<String, Variant<MessageItem>>>()
-                    .unwrap_or_else(HashMap::new)
-                    .get("offset")
-                    .and_then(RefArg::as_u64)
-                    .unwrap_or(0) as u16;
-                let mret = method_info.msg.method_return();
-
-                method_info
-                    .path
-                    .get_data()
-                    .get_characteristic()
-                    .properties
-                    .read
-                    .clone()
-                    .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))
-                    .into_future()
-                    .and_then(move |event_sender| {
+        let iface_token = tree.register::<GattDataType, _, _>(GATT_CHARACTERISTIC_IFACE, |b| {
+            let message_sender = message_sender.clone();
+            b.method_with_cr_async(
+                "ReadValue",
+                ("options",),
+                ("value",),
+                |mut ctx, cr, (options,): (OptionsMap,)| {
+                    let offset = options.get("offset").and_then(RefArg::as_u64).unwrap_or(0) as u16;
+                    let characteristic = cr
+                        .data_mut::<GattDataType>(ctx.path())
+                        .unwrap()
+                        .get_characteristic();
+                    async move {
+                        let event_sender = characteristic
+                            .properties
+                            .read
+                            .clone()
+                            .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?;
                         let (sender, receiver) = oneshot::channel();
                         event_sender
                             .sender()
@@ -165,38 +94,35 @@ impl Characteristic {
                                 offset,
                                 response: sender,
                             }))
-                            .map_err(move |_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
-                            .and_then(move |_| {
-                                receiver.map_err(move |_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
+                            .await
+                            .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))?;
+                        receiver
+                            .await
+                            .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
+                            .and_then(|resp| match resp {
+                                gatt::event::Response::Success(value) => Ok((value,)),
+                                _ => Err(MethodErr::from((BLUEZ_ERROR_FAILED, ""))),
                             })
-                    })
-                    .and_then(move |response| match response {
-                        gatt::event::Response::Success(value) => Ok(vec![mret.append1(value)]),
-                        _ => Err(MethodErr::from((BLUEZ_ERROR_FAILED, ""))),
-                    })
-            }))
-            .add_m(factory.amethod("WriteValue", (), move |method_info| {
-                let (data, flags) = method_info
-                    .msg
-                    .get2::<Vec<u8>, HashMap<String, Variant<MessageItem>>>();
-                let data = data.unwrap_or_else(Vec::new);
-                let offset = flags
-                    .unwrap_or_else(HashMap::new)
-                    .get("offset")
-                    .and_then(RefArg::as_u64)
-                    .unwrap_or(0) as u16;
-                let mret = method_info.msg.method_return();
-
-                method_info
-                    .path
-                    .get_data()
-                    .get_characteristic()
-                    .properties
-                    .write
-                    .clone()
-                    .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))
-                    .into_future()
-                    .and_then(move |event_sender| {
+                    }
+                    .map(move |result| ctx.reply(result))
+                },
+            );
+            b.method_with_cr_async(
+                "WriteValue",
+                ("data", "options"),
+                ("value",),
+                |mut ctx, cr, (data, options): (Vec<u8>, OptionsMap)| {
+                    let offset = options.get("offset").and_then(RefArg::as_u64).unwrap_or(0) as u16;
+                    let characteristic = cr
+                        .data_mut::<GattDataType>(ctx.path())
+                        .unwrap()
+                        .get_characteristic();
+                    async move {
+                        let event_sender = characteristic
+                            .properties
+                            .write
+                            .clone()
+                            .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?;
                         let (sender, receiver) = oneshot::channel();
                         event_sender
                             .sender()
@@ -208,118 +134,79 @@ impl Characteristic {
                                     response: sender,
                                 },
                             ))
+                            .await
+                            .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))?;
+                        receiver
+                            .await
                             .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
-                            .and_then(move |_| {
-                                receiver.map_err(move |_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
+                            .and_then(|resp| match resp {
+                                gatt::event::Response::Success(value) => Ok((value,)),
+                                _ => Err(MethodErr::from((BLUEZ_ERROR_FAILED, ""))),
                             })
-                    })
-                    .and_then(move |response| match response {
-                        gatt::event::Response::Success(value) => Ok(vec![mret.append1(value)]),
-                        _ => Err(MethodErr::from((BLUEZ_ERROR_FAILED, ""))),
-                    })
-            }))
-            .add_m(factory.amethod("StartNotify", (), move |method_info| {
-                let (sender, receiver) = mpsc::channel(1);
-                let notify_subscribe = gatt::event::NotifySubscribe {
-                    notification: sender,
-                };
-
-                let message_sender = message_sender.clone();
-                thread::spawn(move || {
-                    for possible_notification in receiver.wait() {
-                        if let Ok(notification) = possible_notification {
-                            block_on_all(message_sender.clone().send(notification)).unwrap();
-                        }
                     }
-                });
+                    .map(move |result| ctx.reply(result))
+                },
+            );
+            b.method_with_cr_async("StartNotify", (), (), move |mut ctx, cr, ()| {
+                let characteristic = cr
+                    .data_mut::<GattDataType>(ctx.path())
+                    .unwrap()
+                    .get_characteristic();
+                let message_sender = message_sender.clone();
+                async move {
+                    let (sender, mut receiver) = mpsc::channel(1);
+                    let notify_subscribe = gatt::event::NotifySubscribe {
+                        notification: sender,
+                    };
+                    tokio::spawn(async move {
+                        while let Some(notification) = receiver.next().await {
+                            let mut message_sender = message_sender.clone();
+                            let _ = message_sender.send(notification).await;
+                        }
+                    });
+                    let mut event_sender = characteristic
+                        .properties
+                        .notify
+                        .clone()
+                        .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?;
+                    event_sender
+                        .send(gatt::event::Event::NotifySubscribe(notify_subscribe))
+                        .await
+                        .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
+                        .map(|_| ())
+                }
+                .map(move |result| ctx.reply(result))
+            });
+            b.method_with_cr_async("StopNotify", (), (), |mut ctx, cr, ()| {
+                let characteristic = cr
+                    .data_mut::<GattDataType>(ctx.path())
+                    .unwrap()
+                    .get_characteristic();
+                async move {
+                    let mut event_sender = characteristic
+                        .properties
+                        .notify
+                        .clone()
+                        .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?;
+                    event_sender
+                        .send(gatt::event::Event::NotifyUnsubscribe)
+                        .await
+                        .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
+                        .map(|_| ())
+                }
+                .map(move |result| ctx.reply(result))
+            });
+            b.property("UUID")
+                .get(|_ctx, data| Ok(data.get_characteristic().uuid.to_string()));
+            let service = service.clone();
+            b.property("Service")
+                .get(move |_ctx, _data| Ok(service.clone()));
+            b.property("Flags")
+                .get(move |_ctx, data| Ok(data.get_characteristic().properties.flags()));
+        });
 
-                method_info
-                    .path
-                    .get_data()
-                    .get_characteristic()
-                    .properties
-                    .notify
-                    .clone()
-                    .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))
-                    .into_future()
-                    .and_then(move |event_sender| {
-                        event_sender
-                            .send(gatt::event::Event::NotifySubscribe(notify_subscribe))
-                            .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
-                    })
-                    .and_then(|_| Ok(vec![]))
-            }))
-            .add_m(factory.amethod("StopNotify", (), move |method_info| {
-                method_info
-                    .path
-                    .get_data()
-                    .get_characteristic()
-                    .properties
-                    .notify
-                    .clone()
-                    .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))
-                    .into_future()
-                    .and_then(move |event_sender| {
-                        event_sender
-                            .send(gatt::event::Event::NotifyUnsubscribe)
-                            .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
-                    })
-                    .and_then(|_| Ok(vec![]))
-            }))
-            .add_p(
-                factory
-                    .property::<&str, _>("UUID", ())
-                    .access(Access::Read)
-                    .on_get(move |i, prop_info| {
-                        i.append(
-                            &prop_info
-                                .path
-                                .get_data()
-                                .get_characteristic()
-                                .uuid
-                                .to_string(),
-                        );
-                        Ok(())
-                    }),
-            )
-            .add_p({
-                let service = service.clone();
-                factory
-                    .property::<Path<'static>, _>("Service", ())
-                    .access(Access::Read)
-                    .on_get(move |i, _| {
-                        i.append(&service);
-                        Ok(())
-                    })
-            })
-            .add_p(
-                factory
-                    .property::<&[&str], _>("Flags", ())
-                    .access(Access::Read)
-                    .on_get(move |i, prop_info| {
-                        i.append(
-                            &prop_info
-                                .path
-                                .get_data()
-                                .get_characteristic()
-                                .properties
-                                .flags(),
-                        );
-                        Ok(())
-                    }),
-            )
-            .add_p(Arc::clone(&value_property));
+        tree.insert(object_path.clone(), &[iface_token], object_path_data);
 
-        let object_path = factory
-            .object_path(object_path_name, object_path_data)
-            .add(gatt_characteristic)
-            .introspectable()
-            .object_manager();
-
-        let path = object_path.get_name().clone();
-
-        tree.insert(object_path);
-
-        Ok(Characteristic { object_path: path })
+        Ok(Characteristic { object_path })
     }
 }

--- a/src/peripheral/bluez/gatt/descriptor.rs
+++ b/src/peripheral/bluez/gatt/descriptor.rs
@@ -1,23 +1,22 @@
 use dbus::{
     arg::{RefArg, Variant},
-    tree::{Access, EmitsChangedSignal, MethodErr},
-    MessageItem, Path,
+    Path,
 };
-use dbus_tokio::tree::AFactory;
-use futures01::{prelude::*, sync::oneshot::channel};
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use dbus_crossroads::MethodErr;
+use futures::{channel::oneshot, prelude::*};
+use std::{collections::HashMap, sync::Arc};
 
 use super::{
     super::{
         common,
+        common::GattDataType,
         constants::{BLUEZ_ERROR_FAILED, BLUEZ_ERROR_NOTSUPPORTED, GATT_DESCRIPTOR_IFACE},
     },
     flags::Flags,
 };
 use crate::{gatt, Error};
+
+type OptionsMap = HashMap<String, Variant<Box<dyn RefArg>>>;
 
 #[derive(Debug, Clone)]
 pub struct Descriptor {
@@ -31,108 +30,61 @@ impl Descriptor {
         characteristic: &Path<'static>,
         index: u64,
     ) -> Result<Self, Error> {
-        let factory = AFactory::new_afn::<common::TData>();
-
         // Setup value property for read / write by other methods
-        let value = Arc::new(Mutex::new(descriptor.value.clone()));
-        let value_property = {
-            let property = factory
-                .property::<&[u8], _>("Value", ())
-                .emits_changed(EmitsChangedSignal::True)
-                .access({
-                    let is_read_only_value =
-                        descriptor.properties.is_read_only() && descriptor.value.is_some();
-                    if is_read_only_value {
-                        Access::Read
-                    } else {
-                        Access::ReadWrite
-                    }
-                })
-                .on_get({
-                    let on_get_value = Arc::clone(&value);
-                    move |i, _| {
-                        let value = on_get_value
-                            .lock()
-                            .unwrap()
+        let iface_token = tree.register::<GattDataType, _, _>(GATT_DESCRIPTOR_IFACE, |b| {
+            b.method_with_cr_async(
+                "ReadValue",
+                ("options",),
+                ("value",),
+                |mut ctx, cr, (options,): (OptionsMap,)| {
+                    let offset = options.get("offset").and_then(RefArg::as_u64).unwrap_or(0) as u16;
+                    let descriptor = cr
+                        .data_mut::<GattDataType>(ctx.path())
+                        .unwrap()
+                        .get_descriptor();
+                    async move {
+                        let event_sender = descriptor
+                            .properties
+                            .read
                             .clone()
-                            .unwrap_or_else(Vec::new);
-                        i.append(value);
-                        Ok(())
-                    }
-                })
-                .on_set({
-                    let on_set_value = Arc::clone(&value);
-                    move |i, _| {
-                        let value = i.read()?;
-                        on_set_value.lock().unwrap().replace(value);
-                        Ok(())
-                    }
-                });
-            Arc::new(property)
-        };
-
-        let gatt_descriptor = factory
-            .interface(GATT_DESCRIPTOR_IFACE, ())
-            .add_m(factory.amethod("ReadValue", (), move |method_info| {
-                let offset = method_info
-                    .msg
-                    .get1::<HashMap<String, Variant<MessageItem>>>()
-                    .unwrap_or_else(HashMap::new)
-                    .get("offset")
-                    .and_then(RefArg::as_u64)
-                    .unwrap_or(0) as u16;
-                let mret = method_info.msg.method_return();
-
-                method_info
-                    .path
-                    .get_data()
-                    .get_descriptor()
-                    .properties
-                    .read
-                    .clone()
-                    .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))
-                    .into_future()
-                    .and_then(move |event_sender| {
-                        let (sender, receiver) = channel();
+                            .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?;
+                        let (sender, receiver) = oneshot::channel();
                         event_sender
                             .sender()
                             .send(gatt::event::Event::ReadRequest(gatt::event::ReadRequest {
                                 offset,
                                 response: sender,
                             }))
-                            .map_err(move |_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
-                            .and_then(move |_| {
-                                receiver.map_err(move |_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
+                            .await
+                            .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))?;
+                        receiver
+                            .await
+                            .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
+                            .and_then(|resp| match resp {
+                                gatt::event::Response::Success(value) => Ok((value,)),
+                                _ => Err(MethodErr::from((BLUEZ_ERROR_FAILED, ""))),
                             })
-                    })
-                    .and_then(move |response| match response {
-                        gatt::event::Response::Success(value) => Ok(vec![mret.append1(value)]),
-                        _ => Err(MethodErr::from((BLUEZ_ERROR_FAILED, ""))),
-                    })
-            }))
-            .add_m(factory.amethod("WriteValue", (), move |method_info| {
-                let (data, flags) = method_info
-                    .msg
-                    .get2::<Vec<u8>, HashMap<String, Variant<MessageItem>>>();
-                let data = data.unwrap_or_else(Vec::new);
-                let offset = flags
-                    .unwrap_or_else(HashMap::new)
-                    .get("offset")
-                    .and_then(RefArg::as_u64)
-                    .unwrap_or(0) as u16;
-                let mret = method_info.msg.method_return();
-
-                method_info
-                    .path
-                    .get_data()
-                    .get_descriptor()
-                    .properties
-                    .write
-                    .clone()
-                    .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))
-                    .into_future()
-                    .and_then(move |event_sender| {
-                        let (sender, receiver) = channel();
+                    }
+                    .map(move |result| ctx.reply(result))
+                },
+            );
+            b.method_with_cr_async(
+                "WriteValue",
+                ("data", "options"),
+                ("value",),
+                |mut ctx, cr, (data, options): (Vec<u8>, OptionsMap)| {
+                    let offset = options.get("offset").and_then(RefArg::as_u64).unwrap_or(0) as u16;
+                    let descriptor = cr
+                        .data_mut::<GattDataType>(ctx.path())
+                        .unwrap()
+                        .get_descriptor();
+                    async move {
+                        let event_sender = descriptor
+                            .properties
+                            .write
+                            .clone()
+                            .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?;
+                        let (sender, receiver) = oneshot::channel();
                         event_sender
                             .sender()
                             .send(gatt::event::Event::WriteRequest(
@@ -143,66 +95,33 @@ impl Descriptor {
                                     response: sender,
                                 },
                             ))
+                            .await
+                            .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))?;
+                        receiver
+                            .await
                             .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
-                            .and_then(move |_| {
-                                receiver.map_err(move |_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))
+                            .and_then(|resp| match resp {
+                                gatt::event::Response::Success(value) => Ok((value,)),
+                                _ => Err(MethodErr::from((BLUEZ_ERROR_FAILED, ""))),
                             })
-                    })
-                    .and_then(move |response| match response {
-                        gatt::event::Response::Success(value) => Ok(vec![mret.append1(value)]),
-                        _ => Err(MethodErr::from((BLUEZ_ERROR_FAILED, ""))),
-                    })
-            }))
-            .add_p(
-                factory
-                    .property::<&str, _>("UUID", ())
-                    .access(Access::Read)
-                    .on_get(move |i, prop_info| {
-                        i.append(&prop_info.path.get_data().get_descriptor().uuid.to_string());
-                        Ok(())
-                    }),
-            )
-            .add_p({
-                let characteristic = characteristic.clone();
-                factory
-                    .property::<Path<'static>, _>("Characteristic", ())
-                    .access(Access::Read)
-                    .on_get(move |i, _| {
-                        i.append(&characteristic);
-                        Ok(())
-                    })
-            })
-            .add_p(
-                factory
-                    .property::<&[&str], _>("Flags", ())
-                    .access(Access::Read)
-                    .on_get(move |i, prop_info| {
-                        i.append(
-                            &prop_info
-                                .path
-                                .get_data()
-                                .get_descriptor()
-                                .properties
-                                .flags(),
-                        );
-                        Ok(())
-                    }),
-            )
-            .add_p(Arc::clone(&value_property));
+                    }
+                    .map(move |result| ctx.reply(result))
+                },
+            );
+            b.property("UUID")
+                .get(|_ctx, data| Ok(data.get_descriptor().uuid.to_string()));
+            let characteristic = characteristic.clone();
+            b.property("Characteristic")
+                .get(move |_ctx, _data| Ok(characteristic.clone()));
+            b.property("Flags")
+                .get(move |_ctx, data| Ok(data.get_descriptor().properties.flags()));
+        });
+        let object_path: Path =
+            format!("{}/descriptor{:04}", characteristic.to_string(), index).into();
+        let object_path_data = common::GattDataType::Descriptor(Arc::clone(descriptor));
 
-        let object_path = factory
-            .object_path(
-                format!("{}/descriptor{:04}", characteristic.to_string(), index),
-                common::GattDataType::Descriptor(Arc::clone(descriptor)),
-            )
-            .add(gatt_descriptor)
-            .introspectable()
-            .object_manager();
+        tree.insert(object_path.clone(), &[iface_token], object_path_data);
 
-        let path = object_path.get_name().clone();
-
-        tree.insert(object_path);
-
-        Ok(Descriptor { object_path: path })
+        Ok(Descriptor { object_path })
     }
 }

--- a/src/peripheral/bluez/mod.rs
+++ b/src/peripheral/bluez/mod.rs
@@ -74,8 +74,8 @@ impl Peripheral {
         Ok(())
     }
 
-    pub async fn is_advertising(self: &Self) -> bool {
-        self.advertisement.is_advertising()
+    pub async fn is_advertising(self: &Self) -> Result<bool, Error> {
+        Ok(self.advertisement.is_advertising())
     }
 
     pub fn add_service(self: &Self, service: &Service) -> Result<(), Error> {

--- a/src/peripheral/bluez/mod.rs
+++ b/src/peripheral/bluez/mod.rs
@@ -6,17 +6,14 @@ mod constants;
 mod error;
 mod gatt;
 
-use futures::{future, prelude::*};
-use std::{
-    string::ToString,
-    sync::{Arc, Mutex},
-};
-use tokio::runtime::current_thread::Runtime;
+use futures::prelude::*;
+use std::{string::ToString, sync::Arc};
 use uuid::Uuid;
 
 use self::{adapter::Adapter, advertisement::Advertisement, connection::Connection, gatt::Gatt};
 use crate::{gatt::service::Service, Error};
 
+#[derive(Debug)]
 pub struct Peripheral {
     adapter: Adapter,
     gatt: Gatt,
@@ -25,23 +22,17 @@ pub struct Peripheral {
 
 impl Peripheral {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(runtime: &Arc<Mutex<Runtime>>) -> impl Future<Output = Result<Self, Error>> {
-        let connection = match Connection::new(Arc::clone(&runtime)) {
-            Ok(connection) => Arc::new(connection),
-            Err(err) => return future::Either::Left(future::err(err)),
-        };
+    pub async fn new() -> Result<Self, Error> {
+        let connection = Arc::new(Connection::new()?);
+        let adapter = Adapter::new(connection.clone()).await?;
+        adapter.powered(true).await?;
+        let gatt = Gatt::new(connection.clone(), adapter.object_path.clone());
+        let advertisement = Advertisement::new(connection, adapter.object_path.clone());
 
-        future::Either::Right(async {
-            let adapter = Adapter::new(connection.clone()).await?;
-            adapter.powered(true).await?;
-            let gatt = Gatt::new(connection.clone(), adapter.object_path.clone());
-            let advertisement = Advertisement::new(connection, adapter.object_path.clone());
-
-            Ok(Peripheral {
-                adapter,
-                gatt,
-                advertisement,
-            })
+        Ok(Peripheral {
+            adapter,
+            gatt,
+            advertisement,
         })
     }
 
@@ -65,7 +56,10 @@ impl Peripheral {
 
         let advertisement = self.advertisement.register();
         let gatt = self.gatt.register();
-        let (stream, ..) = futures::join!(gatt, advertisement);
+        let (stream, ad_result) = futures::join!(gatt, advertisement);
+        if let Err(e) = ad_result {
+            log::error!("Failed to register advertisement: {}", e);
+        }
         stream
     }
 
@@ -73,7 +67,9 @@ impl Peripheral {
         let advertisement = self.advertisement.unregister();
         let gatt = self.gatt.unregister();
         let (ad_result, gatt_result) = futures::join!(advertisement, gatt);
-        ad_result?;
+        if let Err(e) = ad_result {
+            log::error!("Failed to unregister advertisement: {}", e);
+        }
         gatt_result?;
         Ok(())
     }

--- a/src/peripheral/corebluetooth/mod.rs
+++ b/src/peripheral/corebluetooth/mod.rs
@@ -7,12 +7,8 @@ mod into_bool;
 mod into_cbuuid;
 mod peripheral_manager;
 
-use futures01::{future, prelude::*};
-use std::{
-    sync::{Arc, Mutex},
-    time,
-};
-use tokio::{runtime::current_thread::Runtime, timer};
+use futures::prelude::*;
+use std::time;
 use uuid::Uuid;
 
 use self::peripheral_manager::PeripheralManager;
@@ -24,40 +20,38 @@ pub struct Peripheral {
 
 impl Peripheral {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(_runtime: &Arc<Mutex<Runtime>>) -> Box<impl Future<Item = Self, Error = Error>> {
-        Box::new(future::ok(Peripheral {
+    pub async fn new() -> Result<Self, Error> {
+        Ok(Peripheral {
             peripheral_manager: PeripheralManager::new(),
-        }))
+        })
     }
 
-    pub fn is_powered(self: &Self) -> Box<impl Future<Item = bool, Error = Error>> {
-        Box::new(future::ok(self.peripheral_manager.is_powered()))
+    pub async fn is_powered(&self) -> Result<bool, Error> {
+        Ok(self.peripheral_manager.is_powered())
     }
 
-    pub fn start_advertising(
+    pub async fn start_advertising(
         self: &Self,
         name: &str,
         uuids: &[Uuid],
-    ) -> Box<impl Future<Item = Box<impl Stream<Item = (), Error = Error>>, Error = Error>> {
+    ) -> Result<impl Stream<Item = ()>, Error> {
         self.peripheral_manager.start_advertising(name, uuids);
 
         // TODO: Create an actual stream
-        let read_stream = timer::Interval::new_interval(time::Duration::from_secs(1))
-            .map(|_| ())
-            .map_err(|_| Error::from(()));
-        Box::new(future::ok(Box::new(read_stream)))
+        let read_stream = tokio::time::interval(time::Duration::from_secs(1)).map(|_| ());
+        Ok(Box::new(read_stream))
     }
 
-    pub fn stop_advertising(self: &Self) -> Box<impl Future<Item = (), Error = Error>> {
+    pub async fn stop_advertising(&self) -> Result<(), Error> {
         self.peripheral_manager.stop_advertising();
-        Box::new(future::ok(()))
+        Ok(())
     }
 
-    pub fn is_advertising(self: &Self) -> Box<impl Future<Item = bool, Error = Error>> {
-        Box::new(future::ok(self.peripheral_manager.is_advertising()))
+    pub async fn is_advertising(&self) -> Result<bool, Error> {
+        Ok(self.peripheral_manager.is_advertising())
     }
 
-    pub fn add_service(self: &Self, service: &Service) -> Result<(), Error> {
+    pub fn add_service(&self, service: &Service) -> Result<(), Error> {
         self.peripheral_manager.add_service(service);
         Ok(())
     }

--- a/tests/peripheral.rs
+++ b/tests/peripheral.rs
@@ -174,10 +174,10 @@ async fn it_advertises_gatt() {
                     advertising_stream.for_each(|_| futures::future::ready(())),
                 )
                 .map(|_| ());
-                let ads_check = async { while !peripheral.is_advertising().await {} };
+                let ads_check = async { while !peripheral.is_advertising().await.unwrap() {} };
                 futures::join!(ads_check, ads_handled);
                 peripheral.stop_advertising().await.unwrap();
-                while peripheral.is_advertising().await {}
+                while peripheral.is_advertising().await.unwrap() {}
                 println!("Peripheral stopped advertising");
             }
             Err(e) => {


### PR DESCRIPTION
This doesn't fully work yet -- the `RegisterApplication` call to bluez fails, and I believe it's because this doesn't implement the dbus object manager interface yet (pending support in `dbus-crossroads`). Otherwise, it's most of the way there! Power on/advertising works, and so does manually poking `ReadValue`/`WriteValue` endpoints.