### PR TITLE
Allow registering services without advertising

### DIFF
--- a/src/peripheral/bluez/mod.rs
+++ b/src/peripheral/bluez/mod.rs
@@ -40,11 +40,15 @@ impl Peripheral {
         self.adapter.is_powered().await
     }
 
-    pub async fn start_advertising(
-        self: &Self,
-        name: &str,
-        uuids: &[Uuid],
-    ) -> Result<impl Stream<Item = ()>, Error> {
+    pub async fn register_gatt(&self) -> Result<impl Stream<Item = ()>, Error> {
+        self.gatt.register().await
+    }
+
+    pub async fn unregister_gatt(&self) -> Result<(), Error> {
+        self.gatt.unregister().await
+    }
+
+    pub async fn start_advertising(self: &Self, name: &str, uuids: &[Uuid]) -> Result<(), Error> {
         self.advertisement.add_name(name);
         self.advertisement.add_uuids(
             uuids
@@ -54,24 +58,11 @@ impl Peripheral {
                 .collect::<Vec<String>>(),
         );
 
-        let advertisement = self.advertisement.register();
-        let gatt = self.gatt.register();
-        let (stream, ad_result) = futures::join!(gatt, advertisement);
-        if let Err(e) = ad_result {
-            log::error!("Failed to register advertisement: {}", e);
-        }
-        stream
+        self.advertisement.register().await
     }
 
     pub async fn stop_advertising(self: &Self) -> Result<(), Error> {
-        let advertisement = self.advertisement.unregister();
-        let gatt = self.gatt.unregister();
-        let (ad_result, gatt_result) = futures::join!(advertisement, gatt);
-        if let Err(e) = ad_result {
-            log::error!("Failed to unregister advertisement: {}", e);
-        }
-        gatt_result?;
-        Ok(())
+        self.advertisement.unregister().await
     }
 
     pub async fn is_advertising(self: &Self) -> Result<bool, Error> {

--- a/src/peripheral/bluez/mod.rs
+++ b/src/peripheral/bluez/mod.rs
@@ -6,7 +6,6 @@ mod constants;
 mod error;
 mod gatt;
 
-use futures::prelude::*;
 use std::{string::ToString, sync::Arc};
 use uuid::Uuid;
 
@@ -40,7 +39,7 @@ impl Peripheral {
         self.adapter.is_powered().await
     }
 
-    pub async fn register_gatt(&self) -> Result<impl Stream<Item = ()>, Error> {
+    pub async fn register_gatt(&self) -> Result<(), Error> {
         self.gatt.register().await
     }
 

--- a/src/peripheral/corebluetooth/mod.rs
+++ b/src/peripheral/corebluetooth/mod.rs
@@ -28,14 +28,11 @@ impl Peripheral {
         Ok(self.peripheral_manager.is_powered())
     }
 
-    pub async fn register_gatt(&self) -> Result<impl Stream<Item = ()>, Error> {
-        // TODO: Create an actual stream
-        let read_stream = tokio::time::interval(time::Duration::from_secs(1)).map(|_| ());
-        Ok(Box::new(read_stream))
+    pub async fn register_gatt(&self) -> Result<(), Error> {
+        Ok(())
     }
 
     pub async fn unregister_gatt(&self) -> Result<(), Error> {
-        // TODO
         Ok(())
     }
 

--- a/src/peripheral/corebluetooth/mod.rs
+++ b/src/peripheral/corebluetooth/mod.rs
@@ -7,8 +7,6 @@ mod into_bool;
 mod into_cbuuid;
 mod peripheral_manager;
 
-use futures::prelude::*;
-use std::time;
 use uuid::Uuid;
 
 use self::peripheral_manager::PeripheralManager;
@@ -30,16 +28,20 @@ impl Peripheral {
         Ok(self.peripheral_manager.is_powered())
     }
 
-    pub async fn start_advertising(
-        self: &Self,
-        name: &str,
-        uuids: &[Uuid],
-    ) -> Result<impl Stream<Item = ()>, Error> {
-        self.peripheral_manager.start_advertising(name, uuids);
-
+    pub async fn register_gatt(&self) -> Result<impl Stream<Item = ()>, Error> {
         // TODO: Create an actual stream
         let read_stream = tokio::time::interval(time::Duration::from_secs(1)).map(|_| ());
         Ok(Box::new(read_stream))
+    }
+
+    pub async fn unregister_gatt(&self) -> Result<(), Error> {
+        // TODO
+        Ok(())
+    }
+
+    pub async fn start_advertising(self: &Self, name: &str, uuids: &[Uuid]) -> Result<(), Error> {
+        self.peripheral_manager.start_advertising(name, uuids);
+        Ok(())
     }
 
     pub async fn stop_advertising(&self) -> Result<(), Error> {


### PR DESCRIPTION
Smaller change this time -- this lets us run GATT services without necessarily advertising on our bluetooth device. Use case is only letting paired devices connect to us without broadcasting all the time. (There's probably a better API for this than this, but I'm not sure what.)