### PR TITLE
Fix BlueZ advertisement registration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ branches:
   only:
   - master
 language: rust
-rust:
-  - nightly
 cache:
   cargo: true
 matrix:


### PR DESCRIPTION
Previously, testing on my laptop, BlueZ tries to call the ObjectManager interface on the advertisement object, fails, and fails the RegisterAdvertisement call.

Could have sworn I saw this work before, but it could have been influenced by other configuration.

This might be related to https://github.com/dfrankland/bluster/issues/32 ?