### PR TITLE
Fallback to indicate if no notify property

### DIFF
--- a/src/peripheral/bluez/gatt/characteristic.rs
+++ b/src/peripheral/bluez/gatt/characteristic.rs
@@ -168,6 +168,7 @@ impl Characteristic {
                         .properties
                         .notify
                         .clone()
+                        .or_else(|| characteristic.properties.indicate.clone())
                         .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?;
                     event_sender
                         .send(gatt::event::Event::NotifySubscribe(notify_subscribe))
@@ -187,6 +188,7 @@ impl Characteristic {
                         .properties
                         .notify
                         .clone()
+                        .or_else(|| characteristic.properties.indicate.clone())
                         .ok_or_else(|| MethodErr::from((BLUEZ_ERROR_NOTSUPPORTED, "")))?;
                     event_sender
                         .send(gatt::event::Event::NotifyUnsubscribe)


### PR DESCRIPTION
Previously, if an indicate property were passed with no notify property, the service would ignore StartNotify requests. This makes us use the indicate property's channel for a characteristic that supports indicate but not notify.