### PR TITLE
Require authed encryption for secure read/write

### DIFF
--- a/src/peripheral/bluez/gatt/flags.rs
+++ b/src/peripheral/bluez/gatt/flags.rs
@@ -11,22 +11,24 @@ impl Flags for CharacteristicProperties {
     fn flags(self: &Self) -> Vec<String> {
         let mut flags = vec![];
         if let Some(ref read) = self.read {
-            let read_flag = match read.0 {
-                characteristic::Secure::Secure(_) => "secure-read",
-                characteristic::Secure::Insecure(_) => "read",
+            let read_flags: &[&str] = match read.0 {
+                characteristic::Secure::Secure(_) => &["secure-read", "encrypt-authenticated-read"],
+                characteristic::Secure::Insecure(_) => &["read"],
             };
-            flags.push(read_flag);
+            flags.extend_from_slice(read_flags);
         }
 
         if let Some(ref write) = self.write {
-            let write_flag = match write {
+            let write_flag: &[&str] = match write {
                 characteristic::Write::WithResponse(secure) => match secure {
-                    characteristic::Secure::Secure(_) => "secure-write",
-                    characteristic::Secure::Insecure(_) => "write",
+                    characteristic::Secure::Secure(_) => {
+                        &["secure-write", "encrypt-authenticated-write"]
+                    }
+                    characteristic::Secure::Insecure(_) => &["write"],
                 },
-                characteristic::Write::WithoutResponse(_) => "write-without-response",
+                characteristic::Write::WithoutResponse(_) => &["write-without-response"],
             };
-            flags.push(write_flag);
+            flags.extend_from_slice(write_flag);
         }
 
         if self.notify.is_some() {
@@ -45,19 +47,19 @@ impl Flags for DescriptorProperties {
     fn flags(self: &Self) -> Vec<String> {
         let mut flags = vec![];
         if let Some(ref read) = self.read {
-            let read_flag = match read.0 {
-                descriptor::Secure::Secure(_) => "secure-read",
-                descriptor::Secure::Insecure(_) => "read",
+            let read_flags: &[&str] = match read.0 {
+                descriptor::Secure::Secure(_) => &["secure-read", "encrypt-authenticated-read"],
+                descriptor::Secure::Insecure(_) => &["read"],
             };
-            flags.push(read_flag);
+            flags.extend_from_slice(read_flags);
         }
 
         if let Some(ref write) = self.write {
-            let write_flag = match write.0 {
-                descriptor::Secure::Secure(_) => "secure-write",
-                descriptor::Secure::Insecure(_) => "write",
+            let write_flags: &[&str] = match write.0 {
+                descriptor::Secure::Secure(_) => &["secure-write", "encrypt-authenticated-write"],
+                descriptor::Secure::Insecure(_) => &["write"],
             };
-            flags.push(write_flag);
+            flags.extend_from_slice(write_flags);
         }
 
         flags.iter().map(|s| String::from(*s)).collect()


### PR DESCRIPTION
This makes bluez require devices to be paired with an authenticated pairing method or trusted in order to read/write. I thought that "secure-read"/"secure-write" would imply some kind of pairing, but it seems to just mean any pairing uses BT 4.2+ Secure Connections crypto.

More fine-grained control might help in the future, but for now I think this makes more sense for the current secure vs insecure API. Maybe `authenticated` should be a separate option.

For my benefit after digging through the bluetooth spec way too much: encrypted means the devices are paired. Authenticated means they used a pairing method that can't be man-in-the-middled (e.g. just-works pairing happens without any user input and isn't MITM-safe). Secure Connection means the connection uses FIPS-approved algorithms.