### PR TITLE
Use BOOL instead of *mut Object for boolean ivars. fixes #44

### DIFF
--- a/src/peripheral/corebluetooth/events.rs
+++ b/src/peripheral/corebluetooth/events.rs
@@ -1,8 +1,4 @@
-use objc::{
-    msg_send,
-    runtime::{Object, Sel, NO, YES},
-    sel, sel_impl,
-};
+use objc::{msg_send, runtime::{BOOL, NO, Object, Sel, YES}, sel, sel_impl};
 use objc_foundation::{INSArray, INSString, NSArray, NSObject, NSString};
 
 use super::{
@@ -37,11 +33,11 @@ pub extern "C" fn peripheral_manager_did_update_state(
             }
             CBManagerState::CBManagerStatePoweredOff => {
                 println!("CBManagerStatePoweredOff");
-                delegate.set_ivar::<*mut Object>(POWERED_ON_IVAR, NO as *mut Object);
+                delegate.set_ivar::<BOOL>(POWERED_ON_IVAR, NO);
             }
             CBManagerState::CBManagerStatePoweredOn => {
                 println!("CBManagerStatePoweredOn");
-                delegate.set_ivar::<*mut Object>(POWERED_ON_IVAR, YES as *mut Object);
+                delegate.set_ivar(POWERED_ON_IVAR, YES);
             }
         };
     }

--- a/src/peripheral/corebluetooth/into_bool.rs
+++ b/src/peripheral/corebluetooth/into_bool.rs
@@ -16,7 +16,8 @@ impl IntoBool for BOOL {
 
 impl IntoBool for *mut Object {
     fn into_bool(self) -> bool {
-        (self as BOOL).into_bool()
+        let nil = 0 as *mut Object;
+        nil != self
     }
 }
 

--- a/src/peripheral/corebluetooth/peripheral_manager.rs
+++ b/src/peripheral/corebluetooth/peripheral_manager.rs
@@ -3,13 +3,7 @@ use std::{
     sync::{Once, ONCE_INIT},
 };
 
-use objc::{
-    class,
-    declare::ClassDecl,
-    msg_send,
-    runtime::{Class, Object, Protocol, Sel, NO, YES},
-    sel, sel_impl,
-};
+use objc::{class, declare::ClassDecl, msg_send, runtime::{BOOL, Class, NO, Object, Protocol, Sel, YES}, sel, sel_impl};
 use objc_foundation::{
     INSArray, INSData, INSDictionary, INSString, NSArray, NSData, NSDictionary, NSObject, NSString,
 };
@@ -50,7 +44,7 @@ impl PeripheralManager {
             decl.add_protocol(Protocol::get("CBPeripheralManagerDelegate").unwrap());
 
             decl.add_ivar::<*mut Object>(PERIPHERAL_MANAGER_IVAR);
-            decl.add_ivar::<*mut Object>(POWERED_ON_IVAR);
+            decl.add_ivar::<BOOL>(POWERED_ON_IVAR);
 
             unsafe {
                 decl.add_method(
@@ -103,7 +97,7 @@ impl PeripheralManager {
         unsafe {
             let powered_on = *self
                 .peripheral_manager_delegate
-                .get_ivar::<*mut Object>(POWERED_ON_IVAR);
+                .get_ivar::<BOOL>(POWERED_ON_IVAR);
             powered_on.into_bool()
         }
     }
@@ -227,7 +221,7 @@ extern "C" fn init(delegate: &mut Object, _cmd: Sel) -> *mut Object {
                                         queue:queue];
         delegate.set_ivar::<*mut Object>(PERIPHERAL_MANAGER_IVAR, obj);
 
-        delegate.set_ivar::<*mut Object>(POWERED_ON_IVAR, NO as *mut Object);
+        delegate.set_ivar::<BOOL>(POWERED_ON_IVAR, NO);
 
         delegate
     }


### PR DESCRIPTION
* redefines `IntoBool` for `*mut Object` to be in terms of nil 
* uses `BOOL` for some boolean ivars instead of `*mut Object`