### PR TITLE
Inform application of MTU when reading

### DIFF
--- a/src/gatt/event.rs
+++ b/src/gatt/event.rs
@@ -12,9 +12,11 @@ pub enum Event {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct ReadRequest {
     pub offset: u16,
     pub response: ResponseSender,
+    pub mtu: u16,
 }
 
 #[derive(Debug)]

--- a/src/peripheral/bluez/gatt/characteristic.rs
+++ b/src/peripheral/bluez/gatt/characteristic.rs
@@ -77,6 +77,8 @@ impl Characteristic {
                 ("value",),
                 |mut ctx, cr, (options,): (OptionsMap,)| {
                     let offset = options.get("offset").and_then(RefArg::as_u64).unwrap_or(0) as u16;
+                    let mtu = options.get("mtu").and_then(RefArg::as_u64).unwrap_or(23) as u16;
+
                     let characteristic = cr
                         .data_mut::<GattDataType>(ctx.path())
                         .unwrap()
@@ -93,6 +95,7 @@ impl Characteristic {
                             .send(gatt::event::Event::ReadRequest(gatt::event::ReadRequest {
                                 offset,
                                 response: sender,
+                                mtu,
                             }))
                             .await
                             .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))?;

--- a/src/peripheral/bluez/gatt/descriptor.rs
+++ b/src/peripheral/bluez/gatt/descriptor.rs
@@ -38,6 +38,7 @@ impl Descriptor {
                 ("value",),
                 |mut ctx, cr, (options,): (OptionsMap,)| {
                     let offset = options.get("offset").and_then(RefArg::as_u64).unwrap_or(0) as u16;
+                    let mtu = options.get("mtu").and_then(RefArg::as_u64).unwrap_or(23) as u16;
                     let descriptor = cr
                         .data_mut::<GattDataType>(ctx.path())
                         .unwrap()
@@ -54,6 +55,7 @@ impl Descriptor {
                             .send(gatt::event::Event::ReadRequest(gatt::event::ReadRequest {
                                 offset,
                                 response: sender,
+                                mtu,
                             }))
                             .await
                             .map_err(|_| MethodErr::from((BLUEZ_ERROR_FAILED, "")))?;


### PR DESCRIPTION
This fixes the first half of https://github.com/dfrankland/bluster/issues/46 (informing the application, not checking), with some caveats:

* This is an API breaking change as users might destructure the ReadRequest struct. Future breakage of that kind is avoided by making the struct non_exhaustive.
* I don't know if 23 is really the default value -- and if the kernel guarantees that it's here, it might be better just to unwrap.
* Informing the application of the negotiated MTU is correct but requires some knowledge of mapping between MTUs and value lengths (which have a difference of 3). It might be better API to just expose the relevant length; ideally it should use the established name for that maximum. (Then the default would be 20).

The second half is harder to fix, as the response is sent through a channel without a back channel. It might be an option just to panic -- after all, it's like running `copy_from_slice` with an overly large slice.